### PR TITLE
29: Updated image size in create and edit pages

### DIFF
--- a/src/app/create-post/page.tsx
+++ b/src/app/create-post/page.tsx
@@ -127,7 +127,7 @@ function CreatePost() {
         value={post.title}
         className="border-b pb-2 text-lg my-4 focus:outline-none w-full font-light text-gray-500 placeholder-gray-500 y-2"
       />
-      {image && <img src={URL.createObjectURL(image)} className="my-4" />}
+      {image && <img src={URL.createObjectURL(image)} className="object-cover h-96 w-4/5 my-4 mx-auto" />}
       <SimpleMDE
         value={post.content}
         onChange={(value) => setPost({ ...post, content: value })}

--- a/src/app/edit-post/[id]/page.tsx
+++ b/src/app/edit-post/[id]/page.tsx
@@ -140,7 +140,7 @@ function EditPost({ params: { id } }: { params: { id: string } }) {
               ? URL.createObjectURL(coverImage)
               : coverImage
           }
-          className="mt-4"
+          className="object-cover h-96 w-4/5 my-4 mx-auto"
         />
       )}
       <SimpleMDE


### PR DESCRIPTION
Reduced the size of the image in edit and create pages to match the size when viewing a blog post.

<img width="767" alt="Screenshot 2024-06-15 at 14 26 23" src="https://github.com/KG700/blog-site/assets/57043346/711adbcd-a45f-4f4e-a430-15b5469d472c">
