### PR TITLE
35: added input component and updated edit and create pages

### DIFF
--- a/src/app/components/blog-input.tsx
+++ b/src/app/components/blog-input.tsx
@@ -1,0 +1,27 @@
+interface Props {
+    name: string
+    label?: string;
+    value?: string;
+    placeholder?: string;
+    isboldFont?: boolean;
+    onChange: any
+  }
+
+export default function BlogInput({ label, name, value, placeholder, isboldFont, onChange }: Props) {
+    let inputClassName = "border-b pb-2 text-xl focus:outline-none w-full text-gray-500 placeholder:text-gray-500 placeholder:font-normal placeholder:text-base y-2";
+
+    if (isboldFont) inputClassName += " font-bold"
+
+    return (
+        <label className="block my-4">
+            <span className="text-sm font-normal">{label ?? ""}</span>
+            <input
+            onChange={onChange}
+            name={name}
+            placeholder={placeholder ?? ""}
+            value={value ?? ""}
+            className={inputClassName}
+            />
+      </label>
+    )
+}

--- a/src/app/create-post/page.tsx
+++ b/src/app/create-post/page.tsx
@@ -12,6 +12,7 @@ import { createPost } from "../../graphql/mutations";
 import { Amplify } from "aws-amplify";
 import config from "../../aws-exports";
 import BlogButton from "../components/blog-button";
+import BlogInput from "../components/blog-input";
 import "easymde/dist/easymde.min.css";
 
 const SimpleMDE = dynamic(() => import("react-simplemde-editor"), {
@@ -114,19 +115,20 @@ function CreatePost() {
         type="primary"
         onClickFn={publishPost}
       />
-      <input
-        onChange={onChange}
+      <BlogInput
         name="author"
-        placeholder="Author's name"
+        label="Author"
         value={post.author ?? ""}
-        className="border-b pb-2 text-lg my-4 focus:outline-none w-full font-light text-gray-500 placeholder-gray-500 y-2"
-      />
-      <input
+        placeholder="Enter name of author"
         onChange={onChange}
+      />
+      <BlogInput
         name="title"
-        placeholder="Title"
-        value={post.title}
-        className="border-b pb-2 text-lg my-4 focus:outline-none w-full font-light text-gray-500 placeholder-gray-500 y-2"
+        label="Title"
+        value={post.title ?? ""}
+        placeholder="Enter blog title"
+        isboldFont={true}
+        onChange={onChange}
       />
       {image &&
         <Image

--- a/src/app/edit-post/[id]/page.tsx
+++ b/src/app/edit-post/[id]/page.tsx
@@ -13,6 +13,7 @@ import { getPost } from "../../../graphql/queries";
 import { Amplify } from "aws-amplify";
 import config from "../../../aws-exports";
 import BlogButton from "../../components/blog-button";
+import BlogInput from "../../components/blog-input";
 import "easymde/dist/easymde.min.css";
 
 const SimpleMDE = dynamic(() => import("react-simplemde-editor"), {
@@ -123,19 +124,20 @@ function EditPost({ params: { id } }: { params: { id: string } }) {
         type="primary"
         onClickFn={() => updateBlogPost(true)}
       />
-      <input
-        onChange={onChange}
+      <BlogInput
         name="author"
-        placeholder="Author's name"
+        label="Author"
         value={post.author ?? ""}
-        className="border-b pb-2 text-2xl my-4 focus:outline-none w-full font-bold text-gray-500 placeholder-gray-500 y-2"
-      />
-      <input
+        placeholder="Enter name of author"
         onChange={onChange}
+      />
+      <BlogInput
         name="title"
-        placeholder="Title"
+        label="Title"
         value={post.title ?? ""}
-        className="border-b pb-2 text-2xl my-4 focus:outline-none w-full font-bold text-gray-500 placeholder-gray-500 y-2"
+        placeholder="Enter blog title"
+        isboldFont={true}
+        onChange={onChange}
       />
       {coverImage && (
         <Image


### PR DESCRIPTION
Added a `<BlogInput>` component that includes a formatted label. It includes an optional `isBoldFont` prop so user can choose font to be bold or not.

<img width="757" alt="Screenshot 2024-06-17 at 18 21 16" src="https://github.com/KG700/blog-site/assets/57043346/5ba1192c-7d3d-4155-b4d3-f72a03ea800a">

Also removed the bold font of placeholder text to make it a bit neater.

<img width="728" alt="Screenshot 2024-06-17 at 18 22 19" src="https://github.com/KG700/blog-site/assets/57043346/210ca8f4-7bd3-4be2-baf1-edf48e76ee58">

Replaced input fields in both Create and Edit pages with the new BlogInput component.
